### PR TITLE
go: install to standard location and fix path setup

### DIFF
--- a/src/.chezmoiscripts/linux/run_once_105-install-go.sh
+++ b/src/.chezmoiscripts/linux/run_once_105-install-go.sh
@@ -27,8 +27,7 @@ main() {
   gpgconf --kill all
   rm -rf "$GNUPGHOME" go.tgz.asc
 
-  go_dir=$(dirname "${GOPATH:-${HOME}/go}")
-  tar -C "$go_dir" -xzf go.tgz
+  sudo tar -C /usr/local -xzf go.tgz
   rm go.tgz
 }
 

--- a/src/dot_profile.tmpl
+++ b/src/dot_profile.tmpl
@@ -59,9 +59,7 @@ main() {
   export ASDF_CONFIG_FILE="$XDG_CONFIG_HOME/asdf/.asdfrc"
 
   # go
-  export GOPATH="$HOME/go"
-  export GOBIN="$GOPATH/bin"
-  export PATH="$GOBIN:$PATH"
+  PATH="${GOROOT:-/usr/local/go}/bin:${GOPATH:-$HOME/go}/bin:$PATH"
 
   # deno
   export DENO_INSTALL="$HOME/.deno"


### PR DESCRIPTION
- install Go to `/usr/local` using `sudo` instead of `$GOPATH` dir
- simplify Go path setup in `dot_profile.tmpl` to use standard paths