### PR TITLE
ci: skip install when tools are already present

### DIFF
--- a/src/.chezmoiscripts/linux/run_once_101-install-rust.sh
+++ b/src/.chezmoiscripts/linux/run_once_101-install-rust.sh
@@ -2,6 +2,11 @@
 set -euxo pipefail
 
 main() {
+  if command -v rustup &>/dev/null; then
+    echo "Rust is already installed: $(rustup --version)"
+    return
+  fi
+
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --no-update-default-toolchain --no-modify-path
 }

--- a/src/.chezmoiscripts/linux/run_once_102-install-deno.sh
+++ b/src/.chezmoiscripts/linux/run_once_102-install-deno.sh
@@ -2,6 +2,11 @@
 set -euxo pipefail
 
 main() {
+  if command -v deno &>/dev/null; then
+    echo "Deno is already installed: $(deno --version | head -1)"
+    return
+  fi
+
   curl -fsSL https://deno.land/install.sh | sh -s -- -y --no-modify-path
 }
 

--- a/src/.chezmoiscripts/linux/run_once_103-install-docker.sh
+++ b/src/.chezmoiscripts/linux/run_once_103-install-docker.sh
@@ -2,6 +2,11 @@
 set -euxo pipefail
 
 main() {
+  if command -v docker &>/dev/null; then
+    echo "Docker is already installed: $(docker --version)"
+    return
+  fi
+
   for pkg in \
     docker.io \
     docker-doc \

--- a/src/.chezmoiscripts/linux/run_once_104-install-terraform.sh
+++ b/src/.chezmoiscripts/linux/run_once_104-install-terraform.sh
@@ -2,6 +2,11 @@
 set -euxo pipefail
 
 main() {
+  if command -v terraform &>/dev/null; then
+    echo "Terraform is already installed: $(terraform --version | head -1)"
+    return
+  fi
+
   echo 'Installing the HashiCorp GPG key...'
   wget -O- https://apt.releases.hashicorp.com/gpg |
     gpg --dearmor |

--- a/src/.chezmoiscripts/linux/run_once_105-install-go.sh
+++ b/src/.chezmoiscripts/linux/run_once_105-install-go.sh
@@ -6,6 +6,11 @@ VERSION_KEY='1.25'
 ARCH='amd64'
 
 main() {
+  if command -v go &>/dev/null; then
+    echo "Go is already installed: $(go version)"
+    return
+  fi
+
   echo "Fetching Go versions JSON from ${VERSIONS_JSON_URL}..."
   local versions_json url sha256
   versions_json=$(curl -fsSL "${VERSIONS_JSON_URL}")

--- a/src/.chezmoiscripts/linux/run_once_106-install-awscli.sh
+++ b/src/.chezmoiscripts/linux/run_once_106-install-awscli.sh
@@ -33,6 +33,11 @@ BfWC9s/USgxchg==
 -----END PGP PUBLIC KEY BLOCK-----'
 
 main() {
+  if command -v aws &>/dev/null; then
+    echo "AWS CLI is already installed: $(aws --version)"
+    return
+  fi
+
   # Download zip
   curl "$URL" -o "awscliv2.zip"
 

--- a/src/.chezmoiscripts/linux/run_once_107-install-gh.sh
+++ b/src/.chezmoiscripts/linux/run_once_107-install-gh.sh
@@ -3,6 +3,11 @@ set -euxo pipefail
 
 # https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 main() {
+  if command -v gh &>/dev/null; then
+    echo "GitHub CLI is already installed: $(gh --version | head -1)"
+    return
+  fi
+
   # Install
   (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) &&
     sudo mkdir -p -m 755 /etc/apt/keyrings &&

--- a/src/.chezmoiscripts/linux/run_once_after_109-install-cargo-binstall.sh
+++ b/src/.chezmoiscripts/linux/run_once_after_109-install-cargo-binstall.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 CARGO_BINSTALL_VERSION="1.17.8"
 
 main() {
+  if command -v cargo-binstall &>/dev/null; then
+    echo "cargo-binstall is already installed: $(cargo-binstall -V)"
+    return
+  fi
+
   echo "Installing cargo-binstall v${CARGO_BINSTALL_VERSION}..."
 
   local arch


### PR DESCRIPTION
- Add command -v checks to 1xx install scripts (rust, deno, docker, terraform, go, awscli, gh, cargo-binstall) to skip installation if the tool is already available on the system
- Speeds up CI on GitHub Actions runners where docker, go, gh, and rust are pre-installed