### PR TITLE
ci: pass --locked through cargo binstall

### DIFF
--- a/src/.chezmoiscripts/linux/run_once_after_201-install-cargo-packages.sh
+++ b/src/.chezmoiscripts/linux/run_once_after_201-install-cargo-packages.sh
@@ -16,7 +16,7 @@ main() {
 
   if command -v cargo-binstall &>/dev/null; then
     echo 'Using cargo-binstall (prebuilt binaries)...'
-    cargo binstall --no-confirm "${packages[@]}"
+    cargo binstall --no-confirm --locked "${packages[@]}"
   else
     echo 'cargo-binstall not found, falling back to cargo install...'
     for package in "${packages[@]}"; do


### PR DESCRIPTION
## Problem

The `ubuntu-22.04` leg of [run 32343726129](https://github.com/r-okm/dotfiles/actions/runs/32343726129/job/96347907038) failed while installing cargo packages:

```
error[E0433]: cannot find `lms` in `crate`
  --> .../palette-0.7.5/src/hsl.rs:46:28
error[E0433]: cannot find `meta` in `xyz`
error: could not compile `palette` (lib) due to 34 previous errors
error: failed to compile `eza v0.23.5`
```

Two things had to line up for this.

**1. `cargo binstall` fell back to a source build.** It queries `api.github.com` for each package's release tag to find a prebuilt artifact, trying the tag both with and without a leading `v`. Those calls are unauthenticated, so they draw on the runner's shared-IP rate limit — all nine lookups took 403:

```
has_release_artifact{... eza-community/eza ... tag: "0.23.5"}: Received status code 403 Forbidden
WARN The package eza v0.23.5 will be installed from source (with cargo)
```

The `ubuntu-24.04` leg got its prebuilt binary on the same commit, so this part is flaky rather than deterministic.

**2. The fallback resolved a broken dependency pair.** binstall's fallback invokes `cargo install` without `--locked`:

```
cargo install eza --version 0.23.5 --root /home/runner/.cargo
```

`palette` 0.7.5 was then paired with `palette_derive` **0.7.7**, whose `src/color_types.rs` emits references to the `lms` module and to `xyz::meta::HasXyzMeta` — neither exists in `palette` 0.7.5. `palette_derive` 0.7.6 has no such references, and eza's own lockfile pins exactly 0.7.6.

## Fix

The hand-rolled fallback loop further down the script already passes `--locked`; only the binstall path did not. `cargo-binstall`'s `--locked` is documented as being *"passed through to all `cargo-install` invocations"*, so one flag makes both paths resolve from the lockfile.

## Verification

- `cargo install --locked eza --version 0.23.5` builds clean — `palette v0.7.5` and `palette_derive v0.7.6` compile together, binary produced, exit 0
- All seven packages (`bat` 0.26.1, `eza` 0.23.5, `fd-find` 10.4.2, `git-delta` 0.19.2, `oxker` 0.9.0, `ripgrep` 15.2.0, `tree-sitter-cli` 0.26.12) ship a `Cargo.lock`, so `--locked` cannot fail for want of one
- The prebuilt path is untouched — `--locked` only affects the source fallback

## Not addressed

The 403s themselves. A rate-limited run still pays for a source build (~12 min vs ~7 min) — it just no longer fails. Passing `GITHUB_TOKEN` to the install step would raise the limit from 60 to 1,000 req/h, but that is a separate change.
