### PR TITLE
setup: build tree-sitter-cli from source instead of taking a prebuilt

### DIFF
--- a/src/.chezmoiscripts/linux/run_once_after_201-install-cargo-packages.sh
+++ b/src/.chezmoiscripts/linux/run_once_after_201-install-cargo-packages.sh
@@ -8,8 +8,26 @@ packages=(
   'git-delta'
   'oxker@0.9.0'
   'ripgrep'
+)
+
+source_packages=(
+  # prebuilt binaries require a newer glibc than Ubuntu 22.04 provides
   'tree-sitter-cli'
 )
+
+install_from_source() {
+  local package="$1"
+  shift
+  if [[ "$package" == *@* ]]; then
+    local name="${package%@*}"
+    local version="${package#*@}"
+    echo "Installing $name version $version from source..."
+    cargo install --locked "$@" "$name" --version "$version"
+  else
+    echo "Installing $package latest version from source..."
+    cargo install --locked "$@" "$package"
+  fi
+}
 
 main() {
   echo 'Installing cargo packages...'
@@ -20,17 +38,15 @@ main() {
   else
     echo 'cargo-binstall not found, falling back to cargo install...'
     for package in "${packages[@]}"; do
-      if [[ "$package" == *@* ]]; then
-        name="${package%@*}"
-        version="${package#*@}"
-        echo "Installing $name version $version..."
-        cargo install --locked "$name" --version "$version"
-      else
-        echo "Installing $package latest version..."
-        cargo install --locked "$package"
-      fi
+      install_from_source "$package"
     done
   fi
+
+  echo 'Installing source-only cargo packages...'
+  for package in "${source_packages[@]}"; do
+    # --force: a broken prebuilt still counts as installed, so plain install skips it
+    install_from_source "$package" --force
+  done
 }
 
 main


### PR DESCRIPTION
## Problem

nvim-treesitter could no longer build parsers:

```
[nvim-treesitter/install/diff] error: Error during "tree-sitter build":
tree-sitter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by tree-sitter)
```

The binary itself is unrunnable — `tree-sitter --version` fails the same way.

**What set it off.** #62 edited this script. It is a `run_once_` script, so changing
its contents changed the hash chezmoi keys it on, and the next `chezmoi apply` re-ran
it. `cargo binstall` then upgraded `tree-sitter-cli` 0.26.8 → 0.26.12 and this time
took the prebuilt binary from GitHub releases, whereas the 0.26.8 already in place had
come from the source-build fallback (`.crates2.json` still carried its `rustc 1.94.1`
metadata). tree-sitter builds its `linux-x64` artifact on an `ubuntu-24.04` runner, so
the prebuilt needs glibc 2.39; the machine is Ubuntu 22.04 with 2.35.

`--locked` from #62 is not implicated — it only affects binstall's source-build
fallback, not the prebuilt-download path. The trigger was purely the re-run.

## Why not pin the version, like `oxker@0.9.0`

Because the glibc floor is a property of the release runner, not of the crate.
`objdump -T` on the published `tree-sitter-linux-x64` artifacts:

| version | glibc floor | runs on Ubuntu 22.04 |
|---|---|---|
| 0.26.12 | **2.39** | ✗ |
| 0.26.8 | **2.39** | ✗ |
| 0.25.10 | 2.34 | ✓ |
| 0.25.0 | **2.39** | ✗ |
| 0.24.7 | 2.29 | ✓ |

`build.yml` names `ubuntu-24.04` for `linux-x64` at both `v0.26.8` and `v0.26.12`, so
pinning 0.26.8 would reproduce the exact same failure. The newest prebuilt that still
links against 2.35 is 0.25.10 — below the 0.26.1 that nvim-treesitter requires
(`TREE_SITTER_MIN_VER` in `health.lua`). **No pin satisfies both constraints.**

The floor is not even monotonic in version (0.25.0 is 2.39, 0.25.10 is 2.34), since it
tracks whatever runner image upstream happened to use. Pinning would mean re-verifying
by hand on every bump.

## Fix

Move `tree-sitter-cli` into a `source_packages` array that always goes through
`cargo install --locked`, bypassing binstall's prebuilt path. A source build links
against whatever glibc the machine has, so the question does not arise. The CI legs
run `ubuntu-22.04` too, so this keeps them off the same binary.

`--force` is needed because a machine that already took a broken prebuilt has it
recorded in `.crates.toml`; a plain `cargo install` would skip it as already installed
and leave the machine broken. Being a `run_once_` script, this only re-runs when the
script's own contents change, so the rebuild cost is rare.

The inline version-splitting branch moves out of the binstall fallback into
`install_from_source` so both paths share it.

## Verification

On Ubuntu 22.04 (glibc 2.35), after `cargo install --locked --force tree-sitter-cli`:

- `tree-sitter --version` → `tree-sitter 0.26.12`
- `objdump -T ~/.cargo/bin/tree-sitter` → highest requirement `GLIBC_2.35` (was 2.39)
- nvim-treesitter rebuilt the `diff` parser end-to-end through the CLI:
  `Downloading` → `Compiling parser` → `Installing parser` → `Language installed`
- `zsh -n` on the script passes
